### PR TITLE
Adds full screen landscape support

### DIFF
--- a/android-exoplayer/src/main/res/drawable/ic_fullscreen.xml
+++ b/android-exoplayer/src/main/res/drawable/ic_fullscreen.xml
@@ -1,0 +1,13 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="20dp"
+    android:height="20dp"
+    android:viewportWidth="20"
+    android:viewportHeight="20">
+  <path
+      android:pathData="M1,13L1,19.001L7,19L7,20L0,20L0,13L1,13ZM20,13L20,20L13,20L13,19L19.001,19.001L19,13L20,13ZM7,0L7,1L1,0.999L1,7L0,7L0,0L7,0ZM20,0L20,7L19,7L19.001,1L13,1L13,0L20,0Z"
+      android:strokeWidth="1"
+      android:fillColor="#ffffff"
+      android:fillAlpha="0.85"
+      android:fillType="evenOdd"
+      android:strokeColor="#00000000"/>
+</vector>

--- a/android-exoplayer/src/main/res/drawable/ic_fullscreen_exit.xml
+++ b/android-exoplayer/src/main/res/drawable/ic_fullscreen_exit.xml
@@ -1,0 +1,13 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="20dp"
+    android:height="20dp"
+    android:viewportWidth="20"
+    android:viewportHeight="20">
+  <path
+      android:pathData="M7,13L7,20L6,20L6,13.999L0,14L0,13L7,13ZM20,13L20,14L13.999,13.999L14,20L13,20L13,13L20,13ZM7,0L7,7L0,7L0,6L6,6.001L6,0L7,0ZM14,0L13.999,6L20,6L20,7L13,7L13,0L14,0Z"
+      android:strokeWidth="1"
+      android:fillColor="#ffffff"
+      android:fillAlpha="0.85"
+      android:fillType="evenOdd"
+      android:strokeColor="#00000000"/>
+</vector>

--- a/android-exoplayer/src/main/res/layout/exo_player_control_view.xml
+++ b/android-exoplayer/src/main/res/layout/exo_player_control_view.xml
@@ -71,6 +71,23 @@
             android:paddingRight="4dp"
             android:includeFontPadding="false"
             android:textColor="#FFBEBEBE"/>
+        <FrameLayout
+            android:id="@+id/exo_fullscreen_button"
+            android:layout_height="40dp"
+            android:layout_width="wrap_content"
+            android:layout_gravity="right">
+
+            <ImageView
+                android:id="@+id/exo_fullscreen_icon"
+                android:layout_width="20dp"
+                android:layout_height="20dp"
+                android:paddingRight="4dp"
+                android:layout_gravity="center"
+                android:adjustViewBounds="true"
+                android:scaleType="fitCenter"
+                android:src="@drawable/ic_fullscreen" />
+
+        </FrameLayout>
     </LinearLayout>
 
 </LinearLayout>


### PR DESCRIPTION
This PR is based of the 4.4.0 tag instead of the latest 5.0.0 release since we can't update our app right now to offer Android X support.
This branch should not be merged into master, rather, a new release tag should be created from it after it is reviewed.

Add an icon in the `playerControlView` that toggles switching to fullscreen

Instead of creating a new Activity to handle the fullscreen video, use a modal dialog with a `Theme_Black_NoTitleBar_Fullscreen`

When toggling through fullscreen, the existing `exoPlayerView` (and controls) are added/removed to/from the main activity's view/dialog