### PR TITLE
fix(ReactExoplayerView): disable audio focus

### DIFF
--- a/Video.js
+++ b/Video.js
@@ -350,6 +350,10 @@ export default class Video extends Component {
   }
 }
 
+Video.defaultProps = {
+  disableFocus: false
+};
+
 Video.propTypes = {
   filter: PropTypes.oneOf([
     FilterType.NONE,

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -146,7 +146,7 @@ class ReactExoplayerView extends FrameLayout implements
     private String textTrackType;
     private Dynamic textTrackValue;
     private ReadableArray textTracks;
-    private boolean disableFocus;
+    private boolean disableFocus = true;
     private boolean preventsDisplaySleepDuringVideoPlayback = true;
     private float mProgressUpdateInterval = 250.0f;
     private boolean playInBackground = false;
@@ -1269,6 +1269,7 @@ class ReactExoplayerView extends FrameLayout implements
 
     public void setDisableFocus(boolean disableFocus) {
         this.disableFocus = disableFocus;
+        requestAudioFocus();
     }
 
     public void setFullscreen(boolean fullscreen) {


### PR DESCRIPTION
Fix when component initialize, the `requestAudioFocus` method always request the focus to `AudioManager` even when the property `disableFocus` is passed by parameter.

The `disableFocus` need to be started with 'true' value and a call to `requestAudioFocus` inside the `setDisableFocus` need to be perfom to update it.

**Important note**: this commit was implemented in the past in a very old version of react-native-video dependency. (3.x.x). At this moment, I'm upgrading to version 5.x.x, so probably these changes are not needed anymore. The intention of this PR is to keep track of these changes in case they are still needed.