### PR TITLE
feat(ExoPlayer): fullscreen support

### DIFF
--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -2,7 +2,9 @@ package com.brentvatne.exoplayer;
 
 import android.annotation.SuppressLint;
 import android.app.Activity;
+import android.app.Dialog;
 import android.content.Context;
+import android.content.pm.ActivityInfo;
 import android.media.AudioManager;
 import android.net.Uri;
 import android.os.Handler;
@@ -10,10 +12,12 @@ import android.os.Message;
 import android.text.TextUtils;
 import android.util.Log;
 import android.view.View;
+import android.view.ViewGroup;
 import android.view.Window;
 import android.view.accessibility.CaptioningManager;
 import android.widget.FrameLayout;
 import android.widget.ImageButton;
+import android.widget.ImageView;
 
 import com.brentvatne.react.R;
 import com.brentvatne.receiver.AudioBecomingNoisyReceiver;
@@ -114,6 +118,8 @@ class ReactExoplayerView extends FrameLayout implements
     private DefaultTrackSelector trackSelector;
     private boolean playerNeedsSource;
 
+    private Dialog mFullScreenDialog;
+
     private int resumeWindow;
     private long resumePosition;
     private boolean loadVideoStarted;
@@ -203,6 +209,8 @@ class ReactExoplayerView extends FrameLayout implements
         audioManager = (AudioManager) context.getSystemService(Context.AUDIO_SERVICE);
         themedReactContext.addLifecycleEventListener(this);
         audioBecomingNoisyReceiver = new AudioBecomingNoisyReceiver(themedReactContext);
+
+        initFullscreenDialog();
     }
 
 
@@ -346,6 +354,16 @@ class ReactExoplayerView extends FrameLayout implements
             }
         });
 
+        // Handle the full screen button event
+        FrameLayout fullScreenButton = playerControlView.findViewById(R.id.exo_fullscreen_button);
+        fullScreenButton.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                setFullscreen(!isFullscreen);
+            }
+        });
+        updateFullScreenIcon(isFullscreen);
+
         // Invoking onPlayerStateChanged event for Player
         eventListener = new Player.EventListener() {
             @Override
@@ -368,10 +386,33 @@ class ReactExoplayerView extends FrameLayout implements
                 LayoutParams.MATCH_PARENT);
         playerControlView.setLayoutParams(layoutParams);
         int indexOfPC = indexOfChild(playerControlView);
+        int indexOfExoPlayerView = indexOfChild(exoPlayerView);
         if (indexOfPC != -1) {
             removeViewAt(indexOfPC);
         }
+        if (indexOfExoPlayerView == -1 || getChildCount() == 0 ) {
+            return;
+        }
         addView(playerControlView, 1, layoutParams);
+    }
+
+    private void updateFullScreenIcon(Boolean fullScreen) {
+        if(playerControlView != null && player != null) {
+            ImageView fullScreenIcon = playerControlView.findViewById(R.id.exo_fullscreen_icon);
+            if (fullScreen) {
+                fullScreenIcon.setImageResource(R.drawable.ic_fullscreen_exit);
+            } else {
+                fullScreenIcon.setImageResource(R.drawable.ic_fullscreen);
+            }
+        }
+    }
+
+    private void enableFullScreenButton(Boolean enable) {
+        if(playerControlView != null) {
+            FrameLayout fullScreenButton = playerControlView.findViewById(R.id.exo_fullscreen_button);
+            fullScreenButton.setAlpha(enable ? 1.0f : 0.5f);
+            fullScreenButton.setEnabled(enable);
+        }
     }
 
     /**
@@ -632,9 +673,10 @@ class ReactExoplayerView extends FrameLayout implements
 
     private void onStopPlayback() {
         if (isFullscreen) {
-            setFullscreen(false);
+            setFullscreen(!isFullscreen);
         }
         audioManager.abandonAudioFocus(this);
+        enableFullScreenButton(false);
     }
 
     private void updateResumePosition() {
@@ -750,6 +792,7 @@ class ReactExoplayerView extends FrameLayout implements
                     playerControlView.show();
                 }
                 setKeepScreenOn(preventsDisplaySleepDuringVideoPlayback);
+                enableFullScreenButton(true);
                 break;
             case Player.STATE_ENDED:
                 text += "ended";
@@ -790,6 +833,45 @@ class ReactExoplayerView extends FrameLayout implements
             eventEmitter.load(player.getDuration(), player.getCurrentPosition(), width, height,
                     getAudioTrackInfo(), getTextTrackInfo(), getVideoTrackInfo(), trackId);
         }
+    }
+
+    private void initFullscreenDialog() {
+        mFullScreenDialog = new Dialog(this.themedReactContext, android.R.style.Theme_Black_NoTitleBar_Fullscreen) {
+            public void onBackPressed() {
+                if (isFullscreen) {
+                    themedReactContext.getCurrentActivity().setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_PORTRAIT);
+                    eventEmitter.fullscreenWillDismiss();
+                    Window window = themedReactContext.getCurrentActivity().getWindow();
+                    window.getDecorView().setSystemUiVisibility(View.SYSTEM_UI_FLAG_VISIBLE);
+                    closeFullscreenVideoDialog();
+                    eventEmitter.fullscreenDidDismiss();
+                }
+                super.onBackPressed();
+            }
+        };
+    }
+
+    private void closeFullscreenVideoDialog() {
+        ((ViewGroup)exoPlayerView.getParent()).removeView(exoPlayerView);
+        ((ViewGroup)playerControlView.getParent()).removeView(playerControlView);
+        LayoutParams layoutParams = new LayoutParams(
+                LayoutParams.MATCH_PARENT,
+                LayoutParams.MATCH_PARENT);
+        addView(exoPlayerView, layoutParams);
+        addView(playerControlView, layoutParams);
+        mFullScreenDialog.dismiss();
+        themedReactContext.getCurrentActivity().setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_PORTRAIT);
+    }
+
+    private void openFullscreenVideoDialog() {
+        ((ViewGroup) exoPlayerView.getParent()).removeView(exoPlayerView);
+        ((ViewGroup)playerControlView.getParent()).removeView(playerControlView);
+        LayoutParams layoutParams = new LayoutParams(
+                LayoutParams.MATCH_PARENT,
+                LayoutParams.MATCH_PARENT);
+        mFullScreenDialog.addContentView(exoPlayerView, layoutParams);
+        mFullScreenDialog.addContentView(playerControlView, layoutParams);
+        mFullScreenDialog.show();
     }
 
     private WritableArray getAudioTrackInfo() {
@@ -1273,8 +1355,9 @@ class ReactExoplayerView extends FrameLayout implements
 
     public void setFullscreen(boolean fullscreen) {
         if (fullscreen == isFullscreen) {
-            return; // Avoid generating events when nothing is changing
+            return;
         }
+        updateFullScreenIcon(fullscreen);
         isFullscreen = fullscreen;
 
         Activity activity = themedReactContext.getCurrentActivity();
@@ -1286,20 +1369,27 @@ class ReactExoplayerView extends FrameLayout implements
         int uiOptions;
         if (isFullscreen) {
             if (Util.SDK_INT >= 19) { // 4.4+
-                uiOptions = SYSTEM_UI_FLAG_HIDE_NAVIGATION
-                        | SYSTEM_UI_FLAG_IMMERSIVE_STICKY
+                uiOptions = SYSTEM_UI_FLAG_IMMERSIVE
+                        | SYSTEM_UI_FLAG_LAYOUT_STABLE
+                        | SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION
+                        | SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN
+                        | SYSTEM_UI_FLAG_HIDE_NAVIGATION
                         | SYSTEM_UI_FLAG_FULLSCREEN;
             } else {
                 uiOptions = SYSTEM_UI_FLAG_HIDE_NAVIGATION
                         | SYSTEM_UI_FLAG_FULLSCREEN;
             }
+            activity.setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_SENSOR_LANDSCAPE);
             eventEmitter.fullscreenWillPresent();
             decorView.setSystemUiVisibility(uiOptions);
+            openFullscreenVideoDialog();
             eventEmitter.fullscreenDidPresent();
         } else {
             uiOptions = View.SYSTEM_UI_FLAG_VISIBLE;
+            activity.setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_PORTRAIT);
             eventEmitter.fullscreenWillDismiss();
             decorView.setSystemUiVisibility(uiOptions);
+            closeFullscreenVideoDialog();
             eventEmitter.fullscreenDidDismiss();
         }
     }

--- a/android-exoplayer/src/main/res/drawable/ic_fullscreen.xml
+++ b/android-exoplayer/src/main/res/drawable/ic_fullscreen.xml
@@ -1,0 +1,13 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="20dp"
+    android:height="20dp"
+    android:viewportWidth="20"
+    android:viewportHeight="20">
+  <path
+      android:pathData="M1,13L1,19.001L7,19L7,20L0,20L0,13L1,13ZM20,13L20,20L13,20L13,19L19.001,19.001L19,13L20,13ZM7,0L7,1L1,0.999L1,7L0,7L0,0L7,0ZM20,0L20,7L19,7L19.001,1L13,1L13,0L20,0Z"
+      android:strokeWidth="1"
+      android:fillColor="#ffffff"
+      android:fillAlpha="0.85"
+      android:fillType="evenOdd"
+      android:strokeColor="#00000000"/>
+</vector>

--- a/android-exoplayer/src/main/res/drawable/ic_fullscreen_exit.xml
+++ b/android-exoplayer/src/main/res/drawable/ic_fullscreen_exit.xml
@@ -1,0 +1,13 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="20dp"
+    android:height="20dp"
+    android:viewportWidth="20"
+    android:viewportHeight="20">
+  <path
+      android:pathData="M7,13L7,20L6,20L6,13.999L0,14L0,13L7,13ZM20,13L20,14L13.999,13.999L14,20L13,20L13,13L20,13ZM7,0L7,7L0,7L0,6L6,6.001L6,0L7,0ZM14,0L13.999,6L20,6L20,7L13,7L13,0L14,0Z"
+      android:strokeWidth="1"
+      android:fillColor="#ffffff"
+      android:fillAlpha="0.85"
+      android:fillType="evenOdd"
+      android:strokeColor="#00000000"/>
+</vector>

--- a/android-exoplayer/src/main/res/layout/exo_player_control_view.xml
+++ b/android-exoplayer/src/main/res/layout/exo_player_control_view.xml
@@ -71,6 +71,23 @@
             android:paddingRight="4dp"
             android:includeFontPadding="false"
             android:textColor="#FFBEBEBE"/>
+        <FrameLayout
+            android:id="@+id/exo_fullscreen_button"
+            android:layout_height="40dp"
+            android:layout_width="wrap_content"
+            android:layout_gravity="right">
+
+            <ImageView
+                android:id="@+id/exo_fullscreen_icon"
+                android:layout_width="20dp"
+                android:layout_height="20dp"
+                android:paddingRight="4dp"
+                android:layout_gravity="center"
+                android:adjustViewBounds="true"
+                android:scaleType="fitCenter"
+                android:src="@drawable/ic_fullscreen" />
+
+        </FrameLayout>
     </LinearLayout>
 
 </LinearLayout>


### PR DESCRIPTION
- Add an icon in the `playerControlView` that toggles switching to fullscreen.
- Instead of creating a new Activity to handle the fullscreen video, use a modal dialog with a `Theme_Black_NoTitleBar_Fullscreen`.
- When toggling through fullscreen, the existing `exoPlayerView` (and controls) are added/removed to/from the main activity's view/dialog.